### PR TITLE
Bugfix/thomas/remove deco on uninstall

### DIFF
--- a/module-validation/src/main/java/jidefx/scene/control/validation/ValidationUtils.java
+++ b/module-validation/src/main/java/jidefx/scene/control/validation/ValidationUtils.java
@@ -359,7 +359,8 @@ public class ValidationUtils {
                     targetNode.getProperties().remove(PROPERTY_ON_FLY_OBSERVABLE_VALUE);
                     targetNode.getProperties().remove(PROPERTY_ON_FLY_LISTENER);
                     targetNode.getProperties().remove(PROPERTY_ON_FLY_EVENT_FILTER);
-
+                    targetNode.getProperties().remove(PROPERTY_VALIDATION_RESULT);
+                    targetNode.getProperties().remove(PROPERTY_VALIDATION_RESULT_MESSAGE);
                     Object onFlyValue = targetNode.getProperties().get(PROPERTY_ON_FLY_OBSERVABLE_VALUE);
                     Object onFlyListener = targetNode.getProperties().get(PROPERTY_ON_FLY_LISTENER);
                     if (onFlyValue instanceof ObservableValue && onFlyListener instanceof ChangeListener) {

--- a/module-validation/src/main/java/jidefx/scene/control/validation/ValidationUtils.java
+++ b/module-validation/src/main/java/jidefx/scene/control/validation/ValidationUtils.java
@@ -353,7 +353,7 @@ public class ValidationUtils {
                 if (eventFilter instanceof EventHandler) {
                     targetNode.removeEventFilter(ValidationEvent.ANY, (EventHandler<ValidationEvent>) eventFilter);
                 }
-
+                DecorationUtils.uninstall(targetNode);
                 Object remove = targetNode.getProperties().remove(PROPERTY_ON_FLY_VALIDATOR);
                 if (remove != null) {
                     targetNode.getProperties().remove(PROPERTY_ON_FLY_OBSERVABLE_VALUE);


### PR DESCRIPTION
I had some issues when uninstalling and reinstalling a validator. (The field gets invisible in certain states and I had to remove the validation in this case).
The first commit removes the messages from the node, as they keep the decorator from beeing regenareted if I reinstall the Validator (the msgs are checked and if they are the same, nor decprator gets installed)
the second commit simply uninstalls the decorator, as it keeps alive if I remove the validator.
These changes are ON_FLY only, but shouldn't be hard to integrate in the other modes


